### PR TITLE
Allow dbFile CSV separator to be passed in as init option

### DIFF
--- a/lib/batch-geocoder.js
+++ b/lib/batch-geocoder.js
@@ -19,7 +19,7 @@ var Geocoder = new Model({
    *
    * @param {string}  dbfile  Path to the db file
    */
-  init: function(dbfile, clientId, privateKey) {
+  init: function(dbfile, clientId, privateKey, separator) {
     this.parseDBFile(dbfile);
     if (privateKey && clientId) {
       googlemaps.config('google-private-key', privateKey);
@@ -34,6 +34,8 @@ var Geocoder = new Model({
 
     this.dbfile = fs.createWriteStream(dbfile, {flags: 'a'});
     this.addresses = [];
+    
+    this.separator = separator || ';'
 
   },
 
@@ -51,7 +53,7 @@ var Geocoder = new Model({
       lines = fileContent.split(/\n/);
 
     lines.forEach(function(line) {
-      var entry = line.split(';'),
+      var entry = line.split(this.separator),
         address = entry[0];
 
       if (entry.length < 3) {
@@ -159,7 +161,7 @@ var Geocoder = new Model({
     this.collection[address] = latLng;
     this.data[address] = latLng;
 
-    this.dbfile.write([address, latLng.lat, latLng.lng].join(';') + '\n');
+    this.dbfile.write([address, latLng.lat, latLng.lng].join(this.separator) + '\n');
     this.trigger('status', {
       total: this.counter,
       current: this.counter - this.requestCounter,
@@ -191,7 +193,7 @@ var Geocoder = new Model({
         break;
     }
     this.data[address] = {error: true};
-    this.dbfile.write(address + ';' + error + '\n');
+    this.dbfile.write(address + this.separator + error + '\n');
   },
 
   /**


### PR DESCRIPTION
I need this as [jekyll](https://jekyllrb.com/docs/) cannot be configured to read CSVs with any separator other than `,`.